### PR TITLE
Fix Absolute Paths

### DIFF
--- a/Python Scripts/GapTimes.py
+++ b/Python Scripts/GapTimes.py
@@ -2,11 +2,11 @@
 import sys
 import os
 import neuron
+import consts
 
 processId = 0
 
-THIS_FOLDER = os.path.dirname(os.path.abspath(__file__))
-my_file = os.path.join(THIS_FOLDER, 'file'+str(processId)+'.csv')
+my_file = os.path.join(consts.PY_SCRIPTS_FOLDER, 'file'+str(processId)+'.csv')
 
 sys.stdout = open(my_file, 'w')
 print('GAP TIME TEST')

--- a/Python Scripts/GapTimes.py
+++ b/Python Scripts/GapTimes.py
@@ -13,8 +13,8 @@ print('GAP TIME TEST')
 
 h = neuron.hoc.HocObject()
 
-h('nrn_load_dll("C:/Users/Joey/Desktop/Stuff/Code/Nerve-Block-Modeling/Current Simulation/models/nrnmech.dll")')
-h('load_file("C:/Users/Joey/Desktop/Stuff/Code/Nerve-Block-Modeling/Current Simulation/CNOW_run.hoc")')
+h('nrn_load_dll("{}")'.format(consts.NRNMECH_DLL))
+h('load_file("{}")'.format(consts.CNOW_RUN_HOC))
 
 dcAmp = -600000
 freq = 10000

--- a/Python Scripts/GnabarExperiment.py
+++ b/Python Scripts/GnabarExperiment.py
@@ -14,8 +14,8 @@ print('Gnabar value,' + str(gnabarValue))
 
 h = neuron.hoc.HocObject()
 
-h('nrn_load_dll("C:/Users/Joey/Desktop/Stuff/Code/Nerve-Block-Modeling/Current Simulation/models/nrnmech.dll")')
-h('load_file("C:/Users/Joey/Desktop/Stuff/Code/Nerve-Block-Modeling/Current Simulation/CNOW_run.hoc")')
+h('nrn_load_dll("{}")'.format(consts.NRNMECH_DLL))
+h('load_file("{}")'.format(consts.CNOW_RUN_HOC))
 
 hocCommand = "changeGnabarFromCenter(" + str(gnabarValue) + ")"
 

--- a/Python Scripts/GnabarExperiment.py
+++ b/Python Scripts/GnabarExperiment.py
@@ -2,12 +2,12 @@
 import sys
 import os
 import neuron
+import consts
 
 gnabarValue = round(float(sys.argv[1]),2)
 processId = int(sys.argv[2])
 
-THIS_FOLDER = os.path.dirname(os.path.abspath(__file__))
-my_file = os.path.join(THIS_FOLDER, 'file'+str(processId)+'.csv')
+my_file = os.path.join(consts.PY_SCRIPTS_FOLDER, 'file'+str(processId)+'.csv')
 
 sys.stdout = open(my_file, 'w')
 print('Gnabar value,' + str(gnabarValue))

--- a/Python Scripts/GnabarMultiThread.py
+++ b/Python Scripts/GnabarMultiThread.py
@@ -5,11 +5,11 @@ import subprocess
 import time
 import math
 import os
+import consts
 
 start = time.clock()
 
-THIS_FOLDER = os.path.dirname(os.path.abspath(__file__))
-my_file = os.path.join(THIS_FOLDER, 'GnabarExperiment.py')
+my_file = os.path.join(consts.PY_SCRIPTS_FOLDER, 'GnabarExperiment.py')
 
 procs = []
 numProcesses = 5

--- a/Python Scripts/MultiThreadTest.py
+++ b/Python Scripts/MultiThreadTest.py
@@ -2,6 +2,7 @@ import sys
 import subprocess
 import time
 import math
+import consts
 
 def roundDownToRes(num, res):
     return res * math.floor(num/res)
@@ -21,7 +22,7 @@ for i in range(numProcesses):
     upperBound = roundDownToRes((maxBound - minBound)/numProcesses * (i+1), resolution) + minBound
     lowerBound = roundUpToRes((maxBound - minBound)/numProcesses * i, resolution) + minBound
     argList = [str(lowerBound), str(upperBound), str(resolution)]
-    proc = subprocess.Popen(['python', '"C:/Users/Joey/Desktop/Stuff/Code/Nerve-Block-Modeling/Python Scripts/RunHoc.py"'] + argList)
+    proc = subprocess.Popen(['python', consts.RUNHOC_PY] + argList)
     procs.append(proc)
 
 

--- a/Python Scripts/RunHoc.py
+++ b/Python Scripts/RunHoc.py
@@ -1,6 +1,7 @@
 import sys
 import neuron
 import threading
+import consts
 
 lowerBound = int(sys.argv[1])
 upperBound = int(sys.argv[2])
@@ -8,8 +9,8 @@ resolution = int(sys.argv[3])
 
 h = neuron.hoc.HocObject()
 
-h('nrn_load_dll(""C:/Users/Joey/Desktop/Stuff/Code/Nerve-Block-Modeling/Current Simulation/models/nrnmech.dll")')
-h('load_file(""C:/Users/Joey/Desktop/Stuff/Code/Nerve-Block-Modeling/Current Simulation/CNOW_run.hoc")')
+h('nrn_load_dll("{}")'.format(consts.NRNMECH_DLL))
+h('load_file("{}")'.format(consts.CNOW_RUN_HOC))
 
 hocCommand = "runTestAcrossParams(" + str(lowerBound) + "," + str(upperBound) + "," + str(resolution) + ",8000,9000,500)"
 

--- a/Python Scripts/SendSMS.py
+++ b/Python Scripts/SendSMS.py
@@ -1,6 +1,7 @@
 # First email input is needed to send the text to the user
 # The text is sent by using email, and it is assumed the user has a verizon phone number
 # Note that raw_input was renamed to input in Python 3
+import consts
 
 # because the same email and password are always used, they can be hard coded
 email = 'alertsimulation@gmail.com'
@@ -9,26 +10,22 @@ password = '@lertSimulation1'
 phoneNumber = input('Input Verizon phone number : ')
 send_to_email = phoneNumber + '@vtext.com'
 
-# workingDir = input('Input working directory for simulations : ')
-workingDir = "C:/Users/Joey/Desktop/Stuff/Code/NEURON/Current Simulation/"
-setWorkingDir = 'chdir("' + workingDir + '")'
-print(setWorkingDir)
 # Run the neuron simulations
 from neuron import h, gui
-h(setWorkingDir)
-h('nrn_load_dll("nrnmech.dll")')
-h('load_file("CNOW_run.hoc")')
+
+h('nrn_load_dll("{}")'.format(consts.NRNMECH_DLL))
+h('load_file("{}")'.format(consts.CNOW_RUN_HOC))
 
 import sys
 oldstdout = sys.stdout
-sys.stdout = open('C:/Users/Joey/Desktop/simulationOutput.csv', 'w')
+sys.stdout = open('./simulationOutput.csv', 'w')
 
 hocCommand = "findThreshold(400000,600000,0,10,50,.1,1,1000)"
 h(hocCommand)
 
 sys.stdout = oldstdout
 
-file = open('C:/Users/Joey/Desktop/simulationOutput.csv', 'r')
+file = open('./simulationOutput.csv', 'r')
 output = file.readlines()
 file.close()
 print(output)

--- a/Python Scripts/ThresholdExperiment.py
+++ b/Python Scripts/ThresholdExperiment.py
@@ -14,8 +14,8 @@ sys.stdout = open(my_file, 'w')
 
 h = neuron.hoc.HocObject()
 
-h('nrn_load_dll("C:/Users/Joey/Desktop/Stuff/Code/Nerve-Block-Modeling/Current Simulation/models/nrnmech.dll")')
-h('load_file("C:/Users/Joey/Desktop/Stuff/Code/Nerve-Block-Modeling/Current Simulation/CNOW_run.hoc")')
+h('nrn_load_dll("{}")'.format(consts.NRNMECH_DLL))
+h('load_file("{}")'.format(consts.CNOW_RUN_HOC))
 h('waveform_sel(1)')
 h('setoffset(0)')
 h('onset1 = 10')

--- a/Python Scripts/ThresholdExperiment.py
+++ b/Python Scripts/ThresholdExperiment.py
@@ -2,13 +2,13 @@
 import sys
 import os
 import neuron
+import consts
 
 startingFreq = int(sys.argv[1])
 freqRange = int(sys.argv[2])
 processId = int(sys.argv[3])
 
-THIS_FOLDER = os.path.dirname(os.path.abspath(__file__))
-my_file = os.path.join(THIS_FOLDER, 'file'+str(processId)+'.csv')
+my_file = os.path.join(consts.PY_SCRIPTS_FOLDER, 'file'+str(processId)+'.csv')
 
 sys.stdout = open(my_file, 'w')
 

--- a/Python Scripts/TresholdMutliThread.py
+++ b/Python Scripts/TresholdMutliThread.py
@@ -5,11 +5,11 @@ import subprocess
 import time
 import math
 import os
+import consts
 
 start = time.clock()
 
-THIS_FOLDER = os.path.dirname(os.path.abspath(__file__))
-my_file = os.path.join(THIS_FOLDER, 'ThresholdExperiment.py')
+my_file = os.path.join(consts.PY_SCRIPTS_FOLDER, 'ThresholdExperiment.py')
 
 procs = []
 numProcesses = 5

--- a/Python Scripts/WaveformComparisonExperiment.py
+++ b/Python Scripts/WaveformComparisonExperiment.py
@@ -19,8 +19,8 @@ h = neuron.hoc.HocObject()
 def hocSetup():
     global processId
     # Load NEURON with all the models and procedures normally available
-    h('nrn_load_dll("L:/Work/GithubRepos/NEURON/Current Simulation/models/nrnmech.dll")')
-    h('load_file("L:/Work/GithubRepos/NEURON/Current Simulation/CNOW_run.hoc")')
+    h('nrn_load_dll("{}")'.format(consts.NRNMECH_DLL))
+    h('load_file("{}")'.format(consts.CNOW_RUN_HOC))
     # Fiber diameter varies across each process
     setDiam = 'changeDiam(' + str(processId) + ')'
     print(setDiam)

--- a/Python Scripts/WaveformComparisonExperiment.py
+++ b/Python Scripts/WaveformComparisonExperiment.py
@@ -2,13 +2,13 @@
 import sys
 import os
 import neuron
+import consts
 
 # get the process id assigned by the master script (WaveformComparisonMultiThread.py)
 processId = int(sys.argv[1])
 
 # create a file for output
-THIS_FOLDER = os.path.dirname(os.path.abspath(__file__))
-my_file = os.path.join(THIS_FOLDER, 'file'+str(processId)+'.csv')
+my_file = os.path.join(consts.PY_SCRIPTS_FOLDER, 'file'+str(processId)+'.csv')
 
 # set standard output to the new file
 sys.stdout = open(my_file, 'w')

--- a/Python Scripts/WaveformComparisonMultiThread.py
+++ b/Python Scripts/WaveformComparisonMultiThread.py
@@ -3,11 +3,11 @@ import subprocess
 import time
 import math
 import os
+import consts
 
 start = time.clock()
 
-THIS_FOLDER = os.path.dirname(os.path.abspath(__file__))
-my_file = os.path.join(THIS_FOLDER, 'WaveformComparisonExperiment.py')
+my_file = os.path.join(consts.PY_SCRIPTS_FOLDER, 'WaveformComparisonExperiment.py')
 
 procs = []
 numProcesses = 5

--- a/Python Scripts/consts.py
+++ b/Python Scripts/consts.py
@@ -6,3 +6,12 @@ import os
 # and make it absolute
 REPO_ROOT_FOLDER = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 PY_SCRIPTS_FOLDER = os.path.join(REPO_ROOT_FOLDER, "Python Scripts")
+
+# Commonly referenced files
+CNOW_RUN_HOC = os.path.join(os.path.join(REPO_ROOT_FOLDER, "Current Simulation"), "CNOW_run.hoc")
+NRNMECH_DLL = None
+
+if os.name == "posix":
+    NRNMECH_DLL = os.path.join(os.path.join(os.path.join(os.path.join(os.path.join(REPO_ROOT_FOLDER, "Current Simulation"), "models"), "x86_64"), ".libs"), "libnrnmech.so")
+else:
+    NRNMECH_DLL = os.path.join(os.path.join(os.path.join(REPO_ROOT_FOLDER, "Current Simulation"), "models"), "nrnmech.dll")

--- a/Python Scripts/consts.py
+++ b/Python Scripts/consts.py
@@ -1,0 +1,8 @@
+""" Defines basic constants for python scripts in this repo"""
+import os
+
+# Kinda ugly, we get the path to this script via dirname and __file__. we then
+# join ".." to get one level up and use `abspath` to simplify the path for us
+# and make it absolute
+REPO_ROOT_FOLDER = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+PY_SCRIPTS_FOLDER = os.path.join(REPO_ROOT_FOLDER, "Python Scripts")


### PR DESCRIPTION
This change adds a `consts.py` file that is referenced by all of the other scripts and includes constants for lots of the various paths that are used. The remaining paths are then based off of one of the constants provided by that file, leading to all of the paths now being relative to the script location. There is also an included fix/enhancement to allow this to work on Linux/Unix machines, by checking the OS being run on and picking the correct path for `libnrnmech.so` instead of `nrnmech.dll`. The commit messages contain some a little more detailed information.

Note: I did test that these appear to run, I have not yet however run one of the scripts to it's completion, as they appear to take quite a long time to run. It's probably worth verifying that before merging this in.

Fixes #50