### PR TITLE
Add shebangs and mark python scripts as executable

### DIFF
--- a/Python Scripts/GapTimes.py
+++ b/Python Scripts/GapTimes.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # This is the script instantiated from GnabarMultiThread.py
 import sys
 import os

--- a/Python Scripts/GnabarExperiment.py
+++ b/Python Scripts/GnabarExperiment.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # This is the script instantiated from GnabarMultiThread.py
 import sys
 import os

--- a/Python Scripts/GnabarMultiThread.py
+++ b/Python Scripts/GnabarMultiThread.py
@@ -1,5 +1,5 @@
+#!/usr/bin/env python3
 # GnabarMultiThread runs multiple simulations concurently for collecting data
-
 import sys
 import subprocess
 import time

--- a/Python Scripts/MultiThreadTest.py
+++ b/Python Scripts/MultiThreadTest.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import sys
 import subprocess
 import time

--- a/Python Scripts/RunHoc.py
+++ b/Python Scripts/RunHoc.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import sys
 import neuron
 import threading

--- a/Python Scripts/SendSMS.py
+++ b/Python Scripts/SendSMS.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # First email input is needed to send the text to the user
 # The text is sent by using email, and it is assumed the user has a verizon phone number
 # Note that raw_input was renamed to input in Python 3

--- a/Python Scripts/ThresholdExperiment.py
+++ b/Python Scripts/ThresholdExperiment.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # This is the script instantiated from GnabarMultiThread.py
 import sys
 import os

--- a/Python Scripts/TresholdMutliThread.py
+++ b/Python Scripts/TresholdMutliThread.py
@@ -1,5 +1,5 @@
+#!/usr/bin/env python3
 # GnabarMultiThread runs multiple simulations concurently for collecting data
-
 import sys
 import subprocess
 import time

--- a/Python Scripts/WaveformComparisonExperiment.py
+++ b/Python Scripts/WaveformComparisonExperiment.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # This is the script instantiated from WaveformComparisonMultiThread.py
 import sys
 import os

--- a/Python Scripts/WaveformComparisonMultiThread.py
+++ b/Python Scripts/WaveformComparisonMultiThread.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import sys
 import subprocess
 import time


### PR DESCRIPTION
Adding shebangs allows the python scripts to be run on Unix OSs like
regular executables instead of requiring the python interpreter to be
invoked directly. To allow this, the scripts also have to be marked as
executable. This marking is preserved by `git` and set when the
repo is cloned on Unix machines. Windows ignores this setting.